### PR TITLE
Added Open Graph tag support and fixed a duplicate entry on findImageInDom

### DIFF
--- a/library/js/bootstrap-linkpreview.js
+++ b/library/js/bootstrap-linkpreview.js
@@ -215,18 +215,21 @@
         },
 
         findTitleInDom: function($dom) {
-            return $dom.find("title").text() ||
-                $dom.find("meta[name=title]").attr("content");
+            return $dom.find("meta[property='og:title']").attr("content") ||
+                   $dom.find("title").text() ||
+                   $dom.find("meta[name=title]").attr("content");
         },
 
         findDescriptionInDom: function($dom) {
-            return $dom.find("meta[name=description]").attr("content");
+            return  $dom.find("meta[property='og:description']").attr("content") ||
+                    $dom.find("meta[name=description]").attr("content") ||
+                    $dom.find("div .description").text();
         },
 
         findImageInDom: function($dom) {
-            var imageSrc = $dom.find("meta[itemprop=image]").attr("content") ||
-                $dom.find("link[rel=image_src]").attr("content") ||
+            var imageSrc = $dom.find("meta[property='og:image'").attr("content") ||
                 $dom.find("meta[itemprop=image]").attr("content") ||
+                $dom.find("link[rel=image_src]").attr("content") ||
                 this.findFirstImageInBody($dom.find("body"));
 
             // maybe the returned url is relative


### PR DESCRIPTION
- Added a few more options when fetching Title, Description and Image/Thumbnail. Namely fetching og: (Facebook’s Open Graph) tags.
- Removed duplicated $dom.find("meta[itemprop=image]").attr("content") entry
